### PR TITLE
fix: improve log level name parsing

### DIFF
--- a/include/util/log.hpp
+++ b/include/util/log.hpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
+#include <string_view>
 
 namespace bitchat
 {
@@ -27,7 +28,8 @@ inline void set_log_level(Level lv)
     global_level() = lv;
 }
 
-inline void set_log_level_by_name(std::string& name)
+// Allow callers to pass string literals or other non-owning strings.
+inline void set_log_level_by_name(std::string_view name)
 {
     if (name == "debug")
         set_log_level(Level::Debug);


### PR DESCRIPTION
## Summary
- make set_log_level_by_name accept string_view and add missing include

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68ae0afe9fe88320a51164d6fc1d8298