### PR TITLE
docs: correct bitchat daemon name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ cmake --build build -j
 
 ## CLI
 
-Server `build/bin/bitcahtd`
+Server `build/bin/bitchatd`
 
 ```bash
 Usage:
-  bitcahtd
+  bitchatd
 ```
 
 Client `build/bin/bitchatctl`
@@ -34,7 +34,7 @@ Commands:
 
 ```bash
 # 1. Start a temporary listener (terminal A)
-./build/bin/bitcahtd
+./build/bin/bitchatd
 
 # 2. Send a command (terminal B)
 ./build/bin/bitchatctl send "hello world"


### PR DESCRIPTION
## Summary
- fix CLI documentation to use `bitchatd` instead of misspelled `bitcahtd`
- verify CLI section for remaining typos

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c7bd2ec83208120718f262d34c0